### PR TITLE
Set up Cursor Cloud dev environment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,17 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+灵测 LingCe is a single TypeScript product with two runnable services, orchestrated from the root `package.json` (npm; no monorepo tooling). Standard commands live in `README.md` and the `package.json` files — reference those rather than duplicating.
+
+- **Services**
+  - Backend: Express API on `:8787`, run via `tsx watch` (no build step for dev). Entry `server/src/index.ts`. Persistence is a local JSON file at `server/data/db.json` (auto-created; no database).
+  - Frontend: Vite + React on `:5173`. `web/vite.config.ts` proxies `/api` → `http://localhost:8787`, so run both together and use `http://localhost:5173` in dev.
+
+- **Run**: `npm run dev` (from repo root) starts both services concurrently. `npm run dev:server` / `npm run dev:web` run them individually. In production (`npm start`) the backend serves the built `web/dist`, so only `:8787` is used — this means `npm start` requires `npm run build` to have run first.
+
+- **Demo mode is the default with zero config**: when YAPI/AI env vars (or in-app project settings) are absent, the platform serves built-in mock interfaces and heuristic AI param-fill/review. End-to-end flows (create project → AI fill → run test → AI review → batch auto-test) all work without any external services or secrets. Note: test runs show network errors / low scores in demo mode because there is no real target backend to hit — this is expected, not a bug.
+
+- **Checks**: there is no lint script. Use `npm --prefix server run typecheck` (`tsc --noEmit`) for the backend and `npm run build` (runs `tsc -b && vite build`) for the frontend as the type/compile checks. There are no automated tests in this repo.
+
+- **Optional (not installed by default)**: Playwright/Chromium for real-browser page checks (`cd server && npm i playwright && npx playwright install chromium`); a real YAPI instance and an OpenAI-compatible LLM endpoint for non-demo usage.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up and verifies the development environment for 灵测 LingCe (AI API testing platform). Adds `AGENTS.md` with durable Cursor Cloud instructions and configures the VM update script (`npm install`).

No application code was modified.

## Environment

- **Stack**: TypeScript, Node.js 22 (repo requires ≥18), npm.
- **Services**: Express backend (`:8787`, `tsx watch`) + Vite React frontend (`:5173`, proxies `/api` → backend). No database (local JSON store). Demo mode works with zero external config.
- **Update script**: `npm install` (root `postinstall` installs both `server` and `web`).

## Verification

- `npm install` — dependencies installed for root, server, web.
- `npm --prefix server run typecheck` — passes.
- `npm run build` — frontend builds successfully.
- `npm run dev` — both services start; backend `/api/projects` responds, frontend serves 200.
- Hello-world flow (demo mode): created a project, used AI one-click param fill, ran a test with AI review, and ran a batch auto-test across all demo interfaces.

[lingce_demo_flow.mp4](https://cursor.com/agents/bc-45c353de-4819-4f28-ae38-d90b7b543646/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Flingce_demo_flow.mp4)

Test failures/low scores shown in the UI are expected in demo mode (no real target backend to hit); the platform itself functions correctly.

[AI auto-filled test parameters](https://cursor.com/agents/bc-45c353de-4819-4f28-ae38-d90b7b543646/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Flingce_ai_fill.webp)
[AI batch test results](https://cursor.com/agents/bc-45c353de-4819-4f28-ae38-d90b7b543646/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Flingce_batch_test.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-45c353de-4819-4f28-ae38-d90b7b543646"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-45c353de-4819-4f28-ae38-d90b7b543646"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

